### PR TITLE
Fix import test

### DIFF
--- a/tests/cl-protobufs-tests.asd
+++ b/tests/cl-protobufs-tests.asd
@@ -163,9 +163,9 @@
    (:module "import-test"
     :serial t
     :pathname ""
-    :components ((:protobuf-source-file "import-proto")
-		 (:protobuf-source-file "import-test-import-1")
+    :components ((:protobuf-source-file "import-test-import-1")
 		 (:protobuf-source-file "import-test-import-2")
+		 (:protobuf-source-file "import-proto")
 		 (:file "import-test")))
 
    (:module "lazy-structure-test"

--- a/tests/import-test.lisp
+++ b/tests/import-test.lisp
@@ -31,3 +31,7 @@ Parameters:
                           "import-test-import-1.proto"))
     (assert-true (string= (second imports)
                           "import-test-import-2.proto"))))
+
+(deftest test-make-structure (import-tests)
+  (assert-true (cl-protobufs.third-party.lisp.cl-protobufs.tests:make-import1))
+  (assert-true (cl-protobufs.third-party.lisp.cl-protobufs.tests:make-import2)))


### PR DESCRIPTION
* Adds an additional test to import-tests which checks that we are able to make the messages that are imported.
* Changes import-test to verify that we are able to load .proto files with import statements when the .proto files are specified in the correct order (with respect to imports). ASDF will not be able to load the .proto files unless the files are specified in the correct order.