### PR TITLE
Fix example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ clear in a moment.
 ```shell
 $ protoc --plugin=protoc-gen-lisp=/usr/local/bin/protoc-gen-lisp \
   --lisp_out=output-file=case-preservation.lisp:/tmp \
-  case-preservation.proto
+  cl-protobufs/tests/case-preservation.proto
 ```
 
 This command should generate a file named `case-preservation.lisp` in the


### PR DESCRIPTION
Since the command is run from the directory containing cl-protobufs
this command will fail, as case-preservation.proto is not present
here. Thanks to dougk for spotting this.