### PR TITLE
Fix bug with group serialization

### DIFF
--- a/serialize.lisp
+++ b/serialize.lisp
@@ -700,7 +700,7 @@ See field-descriptor for the distinction between index, offset, and bool-number.
                          `(let ((,vval ,reader))
                             (when ,vval
                               (iincf ,size (encode-uint32 ,tag1 ,vbuf))
-                              ,(call-pseudo-method :serialize msg vval vbuf)
+                              (iincf ,size ,(call-pseudo-method :serialize msg vval vbuf))
                               (iincf ,size (encode-uint32 ,tag2 ,vbuf)))))
                        (let ((tag (make-tag $wire-type-string index)))
                          `(let ((,vval ,reader))

--- a/serialize.lisp
+++ b/serialize.lisp
@@ -656,7 +656,7 @@ See field-descriptor for the distinction between index, offset, and bool-number.
                            `(when ,boundp
                               (,iterator (,vval ,reader)
                                          (iincf ,size (encode-uint32 ,tag1 ,vbuf))
-                                         ,(call-pseudo-method :serialize msg vval vbuf)
+                                         (iincf ,size ,(call-pseudo-method :serialize msg vval vbuf))
                                          (iincf ,size (encode-uint32 ,tag2 ,vbuf)))))
                          (let ((tag (make-tag $wire-type-string index)))
                            `(when ,boundp

--- a/serialize.lisp
+++ b/serialize.lisp
@@ -6,7 +6,6 @@
 
 (in-package "PROTO-IMPL")
 
-
 ;;; Protobuf serialization from Lisp objects
 
 ;;; When the optimize speed option is used we avoid using DEFMETHOD, which generates
@@ -656,7 +655,8 @@ See field-descriptor for the distinction between index, offset, and bool-number.
                            `(when ,boundp
                               (,iterator (,vval ,reader)
                                          (iincf ,size (encode-uint32 ,tag1 ,vbuf))
-                                         (iincf ,size ,(call-pseudo-method :serialize msg vval vbuf))
+                                         (iincf ,size ,(call-pseudo-method :serialize
+                                                                           msg vval vbuf))
                                          (iincf ,size (encode-uint32 ,tag2 ,vbuf)))))
                          (let ((tag (make-tag $wire-type-string index)))
                            `(when ,boundp

--- a/tests/serialization-tests.lisp
+++ b/tests/serialization-tests.lisp
@@ -596,7 +596,7 @@ Parameters:
          (wheel2 (make-color-wheel2 :name "Colors" :metadata meta2))
          (color2 (make-color2 :r-value 100 :g-value 0 :b-value 100))
          (rqst2  (make-add-color2 :wheel wheel2 :color color2))
-	 (rqst3  (make-color-wheel2-wrap :id 9001 :wheel wheel2 :metaname "meta")))
+         (rqst3  (make-color-wheel2-wrap :id 9001 :wheel wheel2 :metaname "meta")))
     (let ((ser1 (serialize-object-to-bytes rqst1 'add-color1))
           (ser2 (serialize-object-to-bytes rqst2 'add-color2)))
       (assert-true (string= (subseq
@@ -624,8 +624,8 @@ Parameters:
       (proto-impl:make-serializer color-wheel2)
       (proto-impl:make-serializer color-wheel2-wrap)
       (let* ((ser3 (serialize-object-to-bytes rqst3 'color-wheel2-wrap))
-	     (res3 (deserialize-object-from-bytes 'color-wheel2-wrap ser3)))
-	(assert-true (proto-equal res3 rqst3))))))
+             (res3 (deserialize-object-from-bytes 'color-wheel2-wrap ser3)))
+        (assert-true (proto-equal res3 rqst3))))))
 
 ;;; We make two protos: ProtoOnWire and ProtoDifferentThanWire.
 ;;; The difference is that ProtoOnWire contains a superset of the

--- a/tests/serialization-tests.lisp
+++ b/tests/serialization-tests.lisp
@@ -595,7 +595,8 @@ Parameters:
          (meta2  (make-metadata :revision "1.0"))
          (wheel2 (make-color-wheel2 :name "Colors" :metadata meta2))
          (color2 (make-color2 :r-value 100 :g-value 0 :b-value 100))
-         (rqst2  (make-add-color2 :wheel wheel2 :color color2)))
+         (rqst2  (make-add-color2 :wheel wheel2 :color color2))
+	 (rqst3  (make-color-wheel2-wrap :id 9001 :wheel wheel2 :metaname "meta")))
     (let ((ser1 (serialize-object-to-bytes rqst1 'add-color1))
           (ser2 (serialize-object-to-bytes rqst2 'add-color2)))
       (assert-true (string= (subseq
@@ -616,7 +617,15 @@ Parameters:
                     (with-output-to-string (s)
                       (print-text-format
                        (deserialize-object 'add-color2 ser2) :stream s))
-                    9))))))
+                    9)))
+      ; this tests the optimized serializer's ability to serialize messages
+      ; which have nested messages which have group fields.
+      (proto-impl:make-serializer metadata)
+      (proto-impl:make-serializer color-wheel2)
+      (proto-impl:make-serializer color-wheel2-wrap)
+      (let* ((ser3 (serialize-object-to-bytes rqst3 'color-wheel2-wrap))
+	     (res3 (deserialize-object-from-bytes 'color-wheel2-wrap ser3)))
+	(assert-true (proto-equal res3 rqst3))))))
 
 ;;; We make two protos: ProtoOnWire and ProtoDifferentThanWire.
 ;;; The difference is that ProtoOnWire contains a superset of the

--- a/tests/serialization.proto
+++ b/tests/serialization.proto
@@ -113,6 +113,12 @@ message ColorWheel2 {
   }
 }
 
+message ColorWheel2Wrap {
+  optional int32 id = 1;
+  optional ColorWheel2 wheel = 2;
+  optional string metaname = 3;
+}
+
 message Color2 {
   optional string name = 1;
   required int32 r_value = 2;


### PR DESCRIPTION
The optimized serializer would compute a smaller than actual
length for protos which contained nested messages which had group
fields (Not sure why someone would ever do this, but it now at
least works).