### PR TITLE
Fix compiler warnings in serialization-test

### DIFF
--- a/tests/serialization-tests.lisp
+++ b/tests/serialization-tests.lisp
@@ -621,6 +621,7 @@ Parameters:
       ; this tests the optimized serializer's ability to serialize messages
       ; which have nested messages which have group fields.
       (proto-impl:make-serializer metadata)
+      (proto-impl:make-serializer color2)
       (proto-impl:make-serializer color-wheel2)
       (proto-impl:make-serializer color-wheel2-wrap)
       (let* ((ser3 (serialize-object-to-bytes rqst3 'color-wheel2-wrap))


### PR DESCRIPTION
Here we create an optimized serializer for color-wheel2, but don't
for color2 (which appears as a submessage). I'm not sure if you are
allowed to do this or not, but the compiler complained about an
undefined function (even though the tests passed before this change).
I'm also not sure why I got this warning now and not when I first
added the test.

This commit simply adds the call to make the serializer for color2,
which gets rid of the warning.