### PR TITLE
Fix unset lazy field bug

### DIFF
--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -557,7 +557,7 @@ Arguments:
       `(defmethod ,lazy-reader :around ((,obj ,proto-type))
          ,(if (not repeated)
               `(let* ((,field-obj (call-next-method))
-                      (,bytes (proto-%bytes ,field-obj)))
+                      (,bytes (and ,field-obj (proto-%bytes ,field-obj))))
                  (if ,bytes
                      ;; Re-create the field object by deserializing its %bytes field.
                      (setf (slot-value ,obj ',slot-name)
@@ -844,7 +844,7 @@ Arguments:
         (defun ,public-accessor-name (,obj)
           ,(if (not repeated)
                `(let* ((,field-obj (,hidden-accessor-name ,obj))
-                       (,bytes (proto-%bytes ,field-obj)))
+                       (,bytes (and ,field-obj (proto-%bytes ,field-obj))))
                   (if ,bytes
                       (setf (,hidden-accessor-name ,obj)
                             ;; Re-create the field object by deserializing its %bytes

--- a/tests/lazy-test.lisp
+++ b/tests/lazy-test.lisp
@@ -133,3 +133,9 @@ Parameters:
     ;; Serialize the restored proto again and verify it's the same as the originally serialized
     ;; value.
     (assert-true (equalp bytes (proto:serialize-object-to-bytes restored)))))
+
+;; Checks that the accessors work for empty lazy fields.
+(deftest test-empty-lazy (lazy-tests)
+  (let ((proto (make-container)))
+    (assert-false (container.inner proto))
+    (assert-false (inner proto))))


### PR DESCRIPTION
I noticed that if you had a lazy field which was unset and you called the accessor on that field, you would get an error. This is because the accessor currently attempts to access the %bytes slot before checking if the message object is even bound. This PR fixes that bug and adds a test. 