### PR TITLE
Use first enum as default rather than lowest index

### DIFF
--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -317,17 +317,10 @@ return nil."
 
 (defun make-enum-default (type enum-values)
   "Generate a function to return the default enum value for
-an enum of type TYPE. The default type should be the enum
-with the lowest index value in ENUM-VALUES."
-  (let ((default-value))
-    (loop with smallest-value = nil
-          for enum in enum-values
-          when (or (not smallest-value)
-                   (< (enum-value-descriptor-value enum) smallest-value))
-            do (setf smallest-value (enum-value-descriptor-value enum)
-                     default-value (enum-value-descriptor-name enum)))
-    `(defmethod enum-default-value ((e (eql ',type)))
-       ,default-value)))
+an enum of type TYPE. The default type should be the first
+enum in ENUM-VALUES."
+  `(defmethod enum-default-value ((e (eql ',type)))
+     ,(enum-value-descriptor-name (car enum-values))))
 
 (defun make-enum-constant-forms (type enum-values)
   "Generates forms for defining a constant for each enum value in ENUM-VALUES.

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -317,7 +317,7 @@ return nil."
 
 (defun make-enum-default (type enum-values)
   "Generate a function to return the default enum value for
-an enum of type TYPE. The default type should be the first
+an enum of type TYPE. The default value should be the first
 enum in ENUM-VALUES."
   `(defmethod enum-default-value ((e (eql ',type)))
      ,(enum-value-descriptor-name (car enum-values))))

--- a/tests/full-tests.lisp
+++ b/tests/full-tests.lisp
@@ -281,6 +281,11 @@ Parameters:
     (proto:clear m)
     (expect-clear m)))
 
+(deftest test-enum-default (full-tests)
+  (let ((m (cl-protobufs.protobuf-unittest:make-sparse-enum-message)))
+    (assert-true (eq (cl-protobufs.protobuf-unittest:sparse-enum-message.sparse-enum m)
+                     :SPARSE-A))))
+
 (deftest test (full-tests)
   (test-parse-from-file)
   (test-parse-packed-from-file)


### PR DESCRIPTION
Proto2 AND proto3 specify that the first enum is always the default.
This code previously used the lowest index enum as the default, which
is incorrect.