### PR TITLE
Make it easy to run all tests from the REPL

### DIFF
--- a/cl-protobufs.asd
+++ b/cl-protobufs.asd
@@ -120,6 +120,11 @@
    ;;   lisp-service-test.lisp not included as the necessary fields in
    ;;   service-test.proto are not currently exported.
 
+   (:module "root-suite"
+            :serial t
+            :pathname ""
+            :components ((:file "root-suite")))
+
    (:module "wire-level-tests"
     :serial t
     :pathname ""
@@ -276,32 +281,10 @@
    (:module "google-tests"
     :serial t
     :pathname ""
-    :depends-on ("brown-tests" "google-tests-proto")
+    :depends-on ("root-suite" "brown-tests" "google-tests-proto")
     :components
     ((:file "full-tests")
      (:static-file "golden_message.data")
      (:static-file "golden_packed_message.data"))))
   :perform (test-op (o c)
-                    (mapc (lambda (p)
-                            (uiop:symbol-call p '#:run))
-                          '(#:cl-protobufs.test.wire-test
-                            #:cl-protobufs.test.case-preservation-test
-                            #:cl-protobufs.test.extend-test
-                            #:cl-protobufs.test.reference-test
-                            #:cl-protobufs.test.serialization-test
-                            #:cl-protobufs.test.symbol-import-test
-                            #:cl-protobufs.test.quick-test
-                            #:cl-protobufs.test.full-test
-                            #:cl-protobufs.test.custom-proto-test
-                            #:cl-protobufs.test.deserialize-test
-                            #:cl-protobufs.test.enum-mapping-test
-                            #:cl-protobufs.test.map-test
-                            #:cl-protobufs.test.oneof-test
-                            #:cl-protobufs.test.import-test
-                            #:cl-protobufs.test.lazy-test
-                            #:cl-protobufs.test.alias-test
-                            #:cl-protobufs.test.packed-test
-                            #:cl-protobufs.test.serialize-test
-                            #:cl-protobufs.test.text-format-test
-                            #:cl-protobufs.test.zigzag-test
-                            #:cl-protobufs.test.well-known-types-test))))
+                    (uiop:symbol-call '#:cl-protobufs.test '#:run-all)))

--- a/tests/case-preservation-test.lisp
+++ b/tests/case-preservation-test.lisp
@@ -13,7 +13,7 @@
 
 (in-package #:cl-protobufs.test.case-preservation-test)
 
-(defsuite case-preservation-tests ())
+(defsuite case-preservation-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/custom-methods.lisp
+++ b/tests/custom-methods.lisp
@@ -55,7 +55,7 @@
 
 (in-package #:cl-protobufs.test.custom-proto-test)
 
-(defsuite custom-proto-tests ())
+(defsuite custom-proto-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/deserialize-object-to-bytes-test.lisp
+++ b/tests/deserialize-object-to-bytes-test.lisp
@@ -12,7 +12,7 @@
 
 (in-package #:cl-protobufs.test.deserialize-test)
 
-(defsuite deserialize-tests ())
+(defsuite deserialize-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/enum-mapping-test.lisp
+++ b/tests/enum-mapping-test.lisp
@@ -15,7 +15,7 @@
 
 (in-package #:cl-protobufs.test.enum-mapping-test)
 
-(defsuite enum-mapping-tests ())
+(defsuite enum-mapping-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/extend-test.lisp
+++ b/tests/extend-test.lisp
@@ -15,7 +15,7 @@
 
 (in-package #:cl-protobufs.test.extend-test)
 
-(defsuite extend-tests ())
+(defsuite extend-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/full-tests.lisp
+++ b/tests/full-tests.lisp
@@ -13,7 +13,7 @@
 
 (in-package #:cl-protobufs.test.full-test)
 
-(defsuite full-tests ())
+(defsuite full-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/import-test.lisp
+++ b/tests/import-test.lisp
@@ -12,7 +12,7 @@
 
 (in-package #:cl-protobufs.test.import-test)
 
-(defsuite import-tests ())
+(defsuite import-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/lazy-test.lisp
+++ b/tests/lazy-test.lisp
@@ -15,7 +15,7 @@
 
 (in-package #:cl-protobufs.test.lazy-test)
 
-(defsuite lazy-tests ())
+(defsuite lazy-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/lisp-alias-test.lisp
+++ b/tests/lisp-alias-test.lisp
@@ -12,7 +12,7 @@
 
 (in-package #:cl-protobufs.test.alias-test)
 
-(defsuite alias-tests ())
+(defsuite alias-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/lisp-reference-tests.lisp
+++ b/tests/lisp-reference-tests.lisp
@@ -23,7 +23,7 @@
 
 (in-package #:cl-protobufs.test.reference-test)
 
-(defsuite reference-tests ())
+(defsuite reference-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/map-test.lisp
+++ b/tests/map-test.lisp
@@ -13,7 +13,7 @@
 
 (in-package #:cl-protobufs.test.map-test)
 
-(defsuite map-tests ())
+(defsuite map-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/oneof-test.lisp
+++ b/tests/oneof-test.lisp
@@ -13,7 +13,7 @@
 
 (in-package #:cl-protobufs.test.oneof-test)
 
-(defsuite oneof-tests ())
+(defsuite oneof-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/packed-test.lisp
+++ b/tests/packed-test.lisp
@@ -14,7 +14,7 @@
 
 (in-package #:cl-protobufs.test.packed-test)
 
-(defsuite packed-tests ())
+(defsuite packed-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/quick-tests.lisp
+++ b/tests/quick-tests.lisp
@@ -12,7 +12,7 @@
 
 (in-package #:cl-protobufs.test.quick-test)
 
-(defsuite quick-tests ())
+(defsuite quick-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/root-suite.lisp
+++ b/tests/root-suite.lisp
@@ -1,0 +1,20 @@
+;;; Copyright 2012-2020 Google LLC
+;;;
+;;; Use of this source code is governed by an MIT-style
+;;; license that can be found in the LICENSE file or at
+;;; https://opensource.org/licenses/MIT.
+
+(defpackage #:cl-protobufs.test
+  (:use #:cl)
+  (:export #:root-suite
+           #:run-all))
+
+(in-package #:cl-protobufs.test)
+
+;;; A suite to contain all other test suites so there's an easy entry point to
+;;; run all tests.
+(clunit:defsuite root-suite ())
+
+(defun run-all ()
+  "Run all tests."
+  (clunit:run-suite 'root-suite))

--- a/tests/serialization-tests.lisp
+++ b/tests/serialization-tests.lisp
@@ -60,7 +60,7 @@
 
 (in-package #:cl-protobufs.test.serialization-test)
 
-(defsuite serialization-tests ())
+(defsuite serialization-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/serialize-object-to-bytes.lisp
+++ b/tests/serialize-object-to-bytes.lisp
@@ -15,7 +15,7 @@
 
 (in-package #:cl-protobufs.test.serialize-test)
 
-(defsuite serialize-tests ())
+(defsuite serialize-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/service-test.lisp
+++ b/tests/service-test.lisp
@@ -15,7 +15,7 @@
 
 (in-package #:cl-protobufs.service-test)
 
-(defsuite service-test ())
+(defsuite service-test (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/symbol-import-tests.lisp
+++ b/tests/symbol-import-tests.lisp
@@ -21,7 +21,7 @@
 
 (in-package #:cl-protobufs.test.symbol-import-test)
 
-(defsuite symbol-import-tests ())
+(defsuite symbol-import-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/text-format-test.lisp
+++ b/tests/text-format-test.lisp
@@ -22,7 +22,7 @@
 
 (in-package :cl-protobufs.test.text-format-test)
 
-(defsuite text-format-tests ())
+(defsuite text-format-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/varint-tests.lisp
+++ b/tests/varint-tests.lisp
@@ -11,7 +11,7 @@
 
 (in-package #:cl-protobufs.test.varint-test)
 
-(defsuite varint-test ())
+(defsuite varint-test (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/well-known-types-test.lisp
+++ b/tests/well-known-types-test.lisp
@@ -13,7 +13,7 @@
 
 (in-package #:cl-protobufs.test.well-known-types-test)
 
-(defsuite well-known-types ())
+(defsuite well-known-types (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/wire-tests.lisp
+++ b/tests/wire-tests.lisp
@@ -37,7 +37,7 @@
 
 (in-package #:cl-protobufs.test.wire-test)
 
-(defsuite wire-tests ())
+(defsuite wire-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.

--- a/tests/zigzag-test.lisp
+++ b/tests/zigzag-test.lisp
@@ -35,7 +35,7 @@
 
 (in-package #:cl-protobufs.test.zigzag-test)
 
-(defsuite wire-tests ())
+(defsuite wire-tests (cl-protobufs.test:root-suite))
 
 (defun run (&optional interactive-p)
   "Run all tests in the test suite.


### PR DESCRIPTION
...by adding all individual suites to a root suite and adding
cl-protobufs.test:run-all. For doing incremental development this can be
preferable since it avoids the sometimes unnecessary step of recompiling all
the files. It also makes it unnecessary to list all the test names in the
defsystem.
