### PR TITLE
Remove some dead clos-transform code

### DIFF
--- a/clos-transform.lisp
+++ b/clos-transform.lisp
@@ -209,38 +209,3 @@ https://developers.google.com/protocol-buffers/docs/proto#scalar "
   (not (null (member type '(:int32 :int64 :uint32 :uint64 :sint32 :sint64
                             :fixed32 :fixed64 :sfixed32 :sfixed64
                             :bool :float :double)))))
-
-(defun protobuf-default-to-clos-init (default type)
-  "Given a Protobufs type and default, return a CLOS initform value.
-   Don't call this if the default is empty, because that will confuse 'nil' with 'unbound'."
-  (cond ((ignore-errors (typep default type))
-         default)
-        ((symbolp default)
-         (cond ((eq type :bool)
-                (boolean-true-p default))
-               ;; If we've got a symbol, it must be to initialize an enum type
-               ;; whose values are represented by keywords in Lisp
-               (t (kintern (symbol-name default)))))
-        ((stringp default)
-         (cond ((eq type :bool)
-                (boolean-true-p default))
-               ((member type '(:int32 :uint32 :int64 :uint64 :sint32 :sint64
-                               :fixed32 :sfixed32 :fixed64 :sfixed64))
-                (let ((default (read-from-string default)))
-                  (and (integerp default) default)))
-               ((member type '(:float :double))
-                (let ((default (read-from-string default)))
-                  (and (floatp default) default)))
-               (t default)))))
-
-(defun boolean-true-p (x)
-  "Returns t or nil given a value that might be a boolean."
-  (etypecase x
-    ((member t nil) x)
-    (integer   (not (eql x 0)))
-    (character (char-equal x #\t))
-    (string    (or (string-equal x "true")
-                   (string-equal x "yes")
-                   (string-equal x "t")
-                   (string-equal x "1")))
-    (symbol    (string-equal (string x) "true"))))

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -1613,8 +1613,7 @@ Arguments
                                           ;; Use unbound for booleans only
                                           (not (eq pclass :bool)))
                                   nil)
-                                 (default-p
-                                  `,(protobuf-default-to-clos-init default type))))))
+                                 (default-p `,default)))))
                  (field (make-instance
                          'field-descriptor
                          :name  (or name (slot-name->proto slot))

--- a/text-format.lisp
+++ b/text-format.lisp
@@ -326,7 +326,8 @@ return T as a second value."
              ((:bool)   (let ((token (parse-token stream)))
                           (cond ((string= token "true") t)
                                 ((string= token "false") nil)
-                                ;; signal an error
+                                ;; Parsing failed, return T as
+                                ;; a second value to signal an error.
                                 (t (values nil t)))))
              (otherwise (parse-signed-int stream))))
           ((typep desc 'message-descriptor)

--- a/text-format.lisp
+++ b/text-format.lisp
@@ -326,8 +326,9 @@ return T as a second value."
              ((:bool)   (let ((token (parse-token stream)))
                           (cond ((string= token "true") t)
                                 ((string= token "false") nil)
-                                ;; Parsing failed, return T as
-                                ;; a second value to signal an error.
+                                ;; Parsing failed, so return T as
+                                ;; a second value to indicate a
+                                ;; failure.
                                 (t (values nil t)))))
              (otherwise (parse-signed-int stream))))
           ((typep desc 'message-descriptor)
@@ -374,6 +375,7 @@ return T as a second value."
                  (t
                   (skip-whitespace stream)
                   (list (parse-map-entry key-type val-type stream)))))))
+          ;; Parsing failed, return t as a second vlaue to indicate failure.
           (t (values nil t)))))
 
 (defun skip-field (stream)

--- a/text-format.lisp
+++ b/text-format.lisp
@@ -323,7 +323,11 @@ return T as a second value."
              ((:float) (parse-float stream))
              ((:double) (parse-double stream))
              ((:string) (parse-string stream))
-             ((:bool)   (boolean-true-p (parse-token stream)))
+             ((:bool)   (let ((token (parse-token stream)))
+                          (cond ((string= token "true") t)
+                                ((string= token "false") nil)
+                                ;; signal an error
+                                (t (values nil t)))))
              (otherwise (parse-signed-int stream))))
           ((typep desc 'message-descriptor)
            (when (eql (peek-char nil stream nil) #\:)


### PR DESCRIPTION
This code was probably used for parsing protos with lisp, but it is no
longer used. The protoc plugin is able to convert from proto custom
defaults to lisp style custom defaults.

note: the entire clos-transform.lisp file is redundant by protoc/literals.cc. I'm currently trying to refactor the code so that it can be safely deleted.