### PR TITLE
Use a plist on the symbol instead of hashmap for proto field accessors

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -143,9 +143,8 @@ only if the same fields have been explicitly set."
 (declaim (inline has-field))
 (defun has-field (object field)
   "Check if OBJECT has FIELD set."
-  (funcall
-   (field-values-has (get field (type-of object)))
-   object))
+  (funcall (field-accessors-has (get field (type-of object)))
+           object))
 
 (declaim (inline proto-slot-value))
 (defun proto-slot-value (object slot)
@@ -153,9 +152,8 @@ only if the same fields have been explicitly set."
 Parameters:
   OBJECT: The protobuf object.
   SLOT: The slot in object to retrieve the value from."
-  (funcall
-   (field-values-get (get slot (type-of object)))
-   object))
+  (funcall (field-accessors-get (get slot (type-of object)))
+           object))
 
 (declaim (inline (setf proto-slot-value)))
 (defun (setf proto-slot-value) (value object slot)
@@ -164,10 +162,9 @@ Parameters:
   VALUE: The new value for the field.
   OBJECT: The protobuf object.
   SLOT: The slot in object to retrieve the value from."
-  (funcall
-   (fdefinition (field-values-set (get slot (type-of object))))
-   value
-   object))
+  (funcall (fdefinition (field-accessors-set (get slot (type-of object))))
+           value
+           object))
 
 (defgeneric encoded-field (object slot)
   (:documentation

--- a/api.lisp
+++ b/api.lisp
@@ -140,14 +140,12 @@ only if the same fields have been explicitly set."
   (:documentation
    "Initialize all of the fields of 'object' to their default values."))
 
+(declaim (inline has-field))
 (defun has-field (object field)
   "Check if OBJECT has FIELD set."
-  (let* ((proto-table
-          (gethash (type-of object)
-                   *proto-function-table*))
-         (has-function
-          (first (gethash field proto-table))))
-    (funcall has-function object)))
+  (funcall
+   (field-values-has (get field (type-of object)))
+   object))
 
 (declaim (inline proto-slot-value))
 (defun proto-slot-value (object slot)
@@ -155,12 +153,9 @@ only if the same fields have been explicitly set."
 Parameters:
   OBJECT: The protobuf object.
   SLOT: The slot in object to retrieve the value from."
-  (let* ((proto-table
-          (gethash (type-of object)
-                   *proto-function-table*))
-         (get-function
-          (second (gethash slot proto-table))))
-    (funcall get-function object)))
+  (funcall
+   (field-values-get (get slot (type-of object)))
+   object))
 
 (declaim (inline (setf proto-slot-value)))
 (defun (setf proto-slot-value) (value object slot)
@@ -169,9 +164,10 @@ Parameters:
   VALUE: The new value for the field.
   OBJECT: The protobuf object.
   SLOT: The slot in object to retrieve the value from."
-  (let* ((fname `(setf ,slot))
-         (setter (fdefinition fname)))
-    (funcall setter value object)))
+  (funcall
+   (fdefinition (field-values-set (get slot (type-of object))))
+   value
+   object))
 
 (defgeneric encoded-field (object slot)
   (:documentation

--- a/api.lisp
+++ b/api.lisp
@@ -146,6 +146,12 @@ only if the same fields have been explicitly set."
   (funcall (field-accessors-has (get field (type-of object)))
            object))
 
+(declaim (inline clear-field))
+(defun clear-field (object field)
+  "Check if OBJECT has FIELD set."
+  (funcall (field-accessors-clear (get field (type-of object)))
+           object))
+
 (declaim (inline proto-slot-value))
 (defun proto-slot-value (object slot)
   "Get the value of a field in a protobuf object.

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -520,21 +520,23 @@ Parameters:
   "Sets the %bytes field of the proto object OBJ with NEW-VALUE."
   (setf (slot-value obj '%bytes) new-value))
 
-(defstruct field-values
+(defstruct field-accessors
   "Structure containing the get, set, and has functions
 for a proto-message field."
   (get nil :type symbol)
   (set nil :type list)
   (has nil :type symbol))
 
-(defun set-field-value-functions (proto-type field-name)
-  "Set the get, set, and has functions for a field onto
-the symbol plist inside of a field-values struct."
-  (setf (get field-name proto-type)
-        (make-field-values
-         :get (proto-slot-function-name proto-type field-name :get)
-         :set `(setf ,(proto-slot-function-name proto-type field-name :get))
-         :has (proto-slot-function-name proto-type field-name :has))))
+(defun set-field-value-functions (message-name field-symbol)
+  "Set the get, set, and has functions for a proto field on a fields symbol p-list.
+Parameters:
+  MESSAGE-NAME: The name of the protobuf message containing the field.
+  FIELD-SYMBOL: The symbol for the field."
+  (setf (get field-symbol message-name)
+        (make-field-accessors
+         :get (proto-slot-function-name message-name field-symbol :get)
+         :set `(setf ,(proto-slot-function-name message-name field-symbol :get))
+         :has (proto-slot-function-name message-name field-symbol :has))))
 
 (defun make-common-forms-for-structure-class (proto-type public-slot-name slot-name field)
   "Create the common forms needed for all message fields

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -525,7 +525,8 @@ Parameters:
 for a proto-message field."
   (get nil :type symbol)
   (set nil :type list)
-  (has nil :type symbol))
+  (has nil :type symbol)
+  (clear nil :type symbol))
 
 (defun set-field-accessor-functions (message-name field-name)
   "Set the get, set, and has functions for a proto field on a fields symbol p-list.
@@ -536,7 +537,8 @@ Parameters:
         (make-field-accessors
          :get (proto-slot-function-name message-name field-name :get)
          :set `(setf ,(proto-slot-function-name message-name field-name :get))
-         :has (proto-slot-function-name message-name field-name :has))))
+         :has (proto-slot-function-name message-name field-name :has)
+         :clear (proto-slot-function-name message-name field-name :clear))))
 
 (defun make-common-forms-for-structure-class (proto-type public-slot-name slot-name field)
   "Create the common forms needed for all message fields

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -174,10 +174,11 @@ the oneof and its nested fields.
   "Validates that all of the IMPORTS (a list of file names) have
    already been loaded. FILE-DESCRIPTOR is the descriptor of the
    file doing the importing."
-  (dolist (import (reverse imports))
-    (let* ((imported (proto:find-schema (if (stringp import) (pathname import) import))))
-      (unless imported
-        (error "Could not find file ~S imported by ~S" import file-descriptor)))))
+  ;; (dolist (import (reverse imports))
+  ;;   (let* ((imported (proto:find-schema (if (stringp import) (pathname import) import))))
+  ;;     (unless imported
+  ;;       (error "Could not find file ~S imported by ~S" import file-descriptor))))
+  )
 
 (defun define-schema (type &key name syntax package import
                            optimize options documentation)
@@ -520,24 +521,21 @@ Parameters:
   "Sets the %bytes field of the proto object OBJ with NEW-VALUE."
   (setf (slot-value obj '%bytes) new-value))
 
-;; As a compile time performance improvement we should see
-;; how big the hash table usually is.
-(defparameter *proto-function-table* (make-hash-table)
-  "Hash table mapping proto-type to a hash-table whose keys are
-field names and values are the field function.")
+(defstruct field-values
+  "Structure containing the get, set, and has functions
+for a proto-message field."
+  (get nil :type symbol)
+  (set nil :type list)
+  (has nil :type symbol))
 
-(defun set-functions-in-hash-table (proto-type field-name)
-  "Add a hash-table to *proto-function-table* for PROTO-TYPE if it does
-not already exist, then add the field functions to the map from FIELD-NAME
-in the found hash-table."
-  (multiple-value-bind (value present)
-      (gethash proto-type *proto-function-table* (make-hash-table))
-    (when (not present)
-      (setf (gethash proto-type *proto-function-table*) value))
-    (setf (gethash field-name value)
-          (list (proto-slot-function-name proto-type field-name :has)
-                (proto-slot-function-name proto-type field-name :get)
-                (proto-slot-function-name proto-type field-name :clear)))))
+(defun set-field-value-functions (proto-type field-name)
+  "Set the get, set, and has functions for a field onto
+the symbol plist inside of a field-values struct."
+  (setf (get field-name proto-type)
+        (make-field-values
+         :get (proto-slot-function-name proto-type field-name :get)
+         :set `(setf ,(proto-slot-function-name proto-type field-name :get))
+         :has (proto-slot-function-name proto-type field-name :has))))
 
 (defun make-common-forms-for-structure-class (proto-type public-slot-name slot-name field)
   "Create the common forms needed for all message fields
@@ -609,12 +607,7 @@ Arguments:
         (defmethod (setf ,public-slot-name) (,new-value (,obj ,proto-type))
           (setf (,public-accessor-name ,obj) ,new-value))
 
-        ;; This must be done outside of proto generation
-        ;; since we reset the hash-table after every  protobuf macro-expansion.
-        ;; Also, for proto-type public-slot-name to have a collison
-        ;; we would need two protos in the same package with the same
-        ;; field, this is impossible.
-        (proto-impl::set-functions-in-hash-table ',proto-type ',public-slot-name)
+        (proto-impl::set-field-value-functions ',proto-type ',public-slot-name)
 
         ;; has-* functions are not exported for singular fields. They are only for
         ;; internal usage.
@@ -722,7 +715,7 @@ Paramters:
                   (defmethod (setf ,public-slot-name) (,new-value (,obj ,proto-type))
                     (setf (,public-accessor-name ,obj) ,new-value))
 
-                  (proto-impl::set-functions-in-hash-table ',proto-type ',public-slot-name)
+                  (proto-impl::set-field-value-functions ',proto-type ',public-slot-name)
 
                   (export '(,has-function-name ,clear-function-name
                             ,public-accessor-name))))))))))

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -174,11 +174,10 @@ the oneof and its nested fields.
   "Validates that all of the IMPORTS (a list of file names) have
    already been loaded. FILE-DESCRIPTOR is the descriptor of the
    file doing the importing."
-  ;; (dolist (import (reverse imports))
-  ;;   (let* ((imported (proto:find-schema (if (stringp import) (pathname import) import))))
-  ;;     (unless imported
-  ;;       (error "Could not find file ~S imported by ~S" import file-descriptor))))
-  )
+  (dolist (import (reverse imports))
+    (let* ((imported (proto:find-schema (if (stringp import) (pathname import) import))))
+      (unless imported
+        (error "Could not find file ~S imported by ~S" import file-descriptor)))))
 
 (defun define-schema (type &key name syntax package import
                            optimize options documentation)

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -527,16 +527,16 @@ for a proto-message field."
   (set nil :type list)
   (has nil :type symbol))
 
-(defun set-field-value-functions (message-name field-symbol)
+(defun set-field-accessor-functions (message-name field-name)
   "Set the get, set, and has functions for a proto field on a fields symbol p-list.
 Parameters:
-  MESSAGE-NAME: The name of the protobuf message containing the field.
-  FIELD-SYMBOL: The symbol for the field."
-  (setf (get field-symbol message-name)
+  MESSAGE-NAME: The symbol name of the protobuf message containing the field.
+  FIELD-NAME: The symbol name for the field."
+  (setf (get field-name message-name)
         (make-field-accessors
-         :get (proto-slot-function-name message-name field-symbol :get)
-         :set `(setf ,(proto-slot-function-name message-name field-symbol :get))
-         :has (proto-slot-function-name message-name field-symbol :has))))
+         :get (proto-slot-function-name message-name field-name :get)
+         :set `(setf ,(proto-slot-function-name message-name field-name :get))
+         :has (proto-slot-function-name message-name field-name :has))))
 
 (defun make-common-forms-for-structure-class (proto-type public-slot-name slot-name field)
   "Create the common forms needed for all message fields
@@ -608,7 +608,7 @@ Arguments:
         (defmethod (setf ,public-slot-name) (,new-value (,obj ,proto-type))
           (setf (,public-accessor-name ,obj) ,new-value))
 
-        (proto-impl::set-field-value-functions ',proto-type ',public-slot-name)
+        (proto-impl::set-field-accessor-functions ',proto-type ',public-slot-name)
 
         ;; has-* functions are not exported for singular fields. They are only for
         ;; internal usage.
@@ -716,7 +716,7 @@ Paramters:
                   (defmethod (setf ,public-slot-name) (,new-value (,obj ,proto-type))
                     (setf (,public-accessor-name ,obj) ,new-value))
 
-                  (proto-impl::set-field-value-functions ',proto-type ',public-slot-name)
+                  (proto-impl::set-field-accessor-functions ',proto-type ',public-slot-name)
 
                   (export '(,has-function-name ,clear-function-name
                             ,public-accessor-name))))))))))

--- a/serialize.lisp
+++ b/serialize.lisp
@@ -131,43 +131,34 @@ Parameters:
   FIELD: The field-descriptor describing which field of OBJECT to serialize.
   BUFFER: The buffer to serialize to."
   (declare (type field-descriptor field))
-  (flet ((read-slot (object slot reader)
-           ;; Don't do a boundp check, we assume the object is fully populated.
-           ;; Unpopulated slots should be "nullable" and will contain nil when empty.
-           (if reader
-               (funcall reader object)
-               (slot-value object slot))))
+  (unless
+      (if (eq (slot-value field 'message-type) :extends)
+          (has-extension object (slot-value field 'internal-field-name))
+          (has-field object (slot-value field 'external-field-name)))
+    (return-from emit-field 0))
+  (let* ((type   (slot-value field 'class))
+         (index  (proto-index field))
+         (value  (cond ((eq (slot-value field 'message-type) :extends)
+                        (get-extension object (slot-value field 'external-field-name)))
+                       ((proto-lazy-p field)
+                        (slot-value object (slot-value field 'internal-field-name)))
+                       (t (proto-slot-value object (slot-value field 'external-field-name))))))
+    ;; For singular fields, only emit if VALUE is not default.
     (when
-        (or (and (eq (slot-value field 'message-type) :extends)
-                 (not (has-extension object (slot-value field 'internal-field-name))))
-            (and (slot-value field 'field-offset)
-                 (= (bit (slot-value object '%%is-set)
-                    (slot-value field 'field-offset))
-                    0)))
+        (and (eq (proto-label field) :singular)
+             (case (proto-set-type field)
+               ((proto:byte-vector cl:string) (= (length value) 0))
+               ((cl:double-float cl:float) (= value (get-default-form (proto-set-type field)
+                                                                      (proto-default field))))
+               (t (eq value (get-default-form (proto-set-type field) (proto-default field))))))
       (return-from emit-field 0))
-    (let* ((type   (slot-value field 'class))
-           (slot   (slot-value field 'internal-field-name))
-           (reader (slot-value field 'reader))
-           (index (proto-index field))
-           ;; If the field is lazy, use slot-value, since calling the reader will
-           ;; unnecessarily deserialize the message.
-           (value (read-slot object slot (and (not (proto-lazy-p field)) reader))))
-      ;; For singular fields, only emit if VALUE is not default.
-      (when
-          (and (eq (proto-label field) :singular)
-               (case (proto-set-type field)
-                 ((proto:byte-vector cl:string) (= (length value) 0))
-                 ((cl:double-float cl:float) (= value (get-default-form (proto-set-type field)
-                                                                        (proto-default field))))
-                 (t (eq value (get-default-form (proto-set-type field) (proto-default field))))))
-        (return-from emit-field 0))
-      (if (eq (proto-label field) :repeated)
-          (or (emit-repeated-field value type (proto-packed field) index buffer)
-              (undefined-field-type "While serializing ~S,"
-                                    object type field))
-          (or (emit-non-repeated-field value type index buffer)
-              (undefined-field-type "While serializing ~S,"
-                                    object type field))))))
+    (if (eq (proto-label field) :repeated)
+        (or (emit-repeated-field value type (proto-packed field) index buffer)
+            (undefined-field-type "While serializing ~S,"
+                                  object type field))
+        (or (emit-non-repeated-field value type index buffer)
+            (undefined-field-type "While serializing ~S,"
+                                  object type field)))))
 
 (defun emit-repeated-field (value type packed-p index buffer)
   "Serialize a repeated field.

--- a/serialize.lisp
+++ b/serialize.lisp
@@ -143,15 +143,6 @@ Parameters:
                        ((proto-lazy-p field)
                         (slot-value object (slot-value field 'internal-field-name)))
                        (t (proto-slot-value object (slot-value field 'external-field-name))))))
-    ;; For singular fields, only emit if VALUE is not default.
-    (when
-        (and (eq (proto-label field) :singular)
-             (case (proto-set-type field)
-               ((proto:byte-vector cl:string) (= (length value) 0))
-               ((cl:double-float cl:float) (= value (get-default-form (proto-set-type field)
-                                                                      (proto-default field))))
-               (t (eq value (get-default-form (proto-set-type field) (proto-default field))))))
-      (return-from emit-field 0))
     (if (eq (proto-label field) :repeated)
         (or (emit-repeated-field value type (proto-packed field) index buffer)
             (undefined-field-type "While serializing ~S,"

--- a/tests/packed-test.lisp
+++ b/tests/packed-test.lisp
@@ -40,7 +40,6 @@
       ;; (format t "~A~%" bytes) ; =>
       ;; #(210 5 3 30 20 10)
       (assert-true (= 6 (length bytes)))
-      (print bytes)
       (assert-true (equalp '(30 20 10) (packed-int32 m2)))
       (assert-true (equalp '(30 20 10) (unpacked-int32 unpacked))))))
 

--- a/text-format.lisp
+++ b/text-format.lisp
@@ -43,8 +43,6 @@ Parameters:
         (let* ((value
                  (cond ((eq (slot-value field 'message-type) :extends)
                         (get-extension object (slot-value field 'external-field-name)))
-                       ((proto-lazy-p field)
-                        (slot-value object (slot-value field 'internal-field-name)))
                        (t (proto-slot-value object (slot-value field 'external-field-name))))))
           ;; For singular fields, only print if VALUE is not default.
           (if (eq (proto-label field) :repeated)

--- a/text-format.lisp
+++ b/text-format.lisp
@@ -41,9 +41,9 @@ Parameters:
                 (has-extension object (slot-value field 'internal-field-name))
                 (has-field object (slot-value field 'external-field-name)))
         (let* ((value
-                 (cond ((eq (slot-value field 'message-type) :extends)
-                        (get-extension object (slot-value field 'external-field-name)))
-                       (t (proto-slot-value object (slot-value field 'external-field-name))))))
+                 (if (eq (slot-value field 'message-type) :extends)
+                     (get-extension object (slot-value field 'external-field-name))
+                     (proto-slot-value object (slot-value field 'external-field-name)))))
           ;; For singular fields, only print if VALUE is not default.
           (if (eq (proto-label field) :repeated)
               (print-repeated-field value


### PR DESCRIPTION
It's cheaper and easier to save the accessor, getter, and has functions
on the plist then to define a global hash-map like we curently do.
So use the plist version.
The performance difference seems to be a wash.