### PR TITLE
Fix text format lazy bug

### DIFF
--- a/text-format.lisp
+++ b/text-format.lisp
@@ -50,7 +50,7 @@ Parameters:
                         0)))
           (let* ((slot   (slot-value field 'internal-field-name))
                  (reader (slot-value field 'reader))
-                 (value (read-slot object slot (and (not (proto-lazy-p field)) reader))))
+                 (value (read-slot object slot reader)))
             ;; For singular fields, only print if VALUE is not default.
             (unless
                 (and (eq (proto-label field) :singular)


### PR DESCRIPTION
This code was lazily copied from the serializer code, in which we want
to hold off from deserializing lazy fields when serializing. Since we
are printing to text, we actually need to deserialize. So, this check
for lazy fields is bad.