### PR TITLE
Fix several asdf compilation notes and warning

### DIFF
--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -1289,8 +1289,7 @@ Arguments:
                                        ,@(and reader `((defmethod ,reader ((object ,type))
                                                          (gethash object ,stable ,default))))
                                        ,@(and writer `((defmethod ,writer ((object ,type) ,stype)
-                                                         (#+sbcl declare #-sbcl declaim
-                                                          (type ,stype value))
+                                                         #-ccl (declare (type ,stype value))
                                                          (setf (gethash object ,stable) value))))
                                        ;; For Python compatibility
                                        (defmethod get-extension ((object ,type)
@@ -1358,8 +1357,7 @@ Arguments:
                        ,@(and reader `((defmethod ,reader ((object ,type))
                                          (gethash object ,stable ,default))))
                        ,@(and writer `((defmethod ,writer ((object ,type) value)
-                                         (#+sbcl declare #-sbcl declaim
-                                           (type ,stype value))
+                                         #-ccl (declare (type ,stype value))
                                          (setf (gethash object ,stable) value))))
                        (defmethod get-extension ((object ,type) (slot (eql ',fname)))
                          (values (gethash object ,stable ,default)))

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -1288,8 +1288,9 @@ Arguments:
                                                      :weakness :key :test #'eq)))
                                        ,@(and reader `((defmethod ,reader ((object ,type))
                                                          (gethash object ,stable ,default))))
-                                       ,@(and writer `((defmethod ,writer ((object ,type) value)
-                                                         (declare (type ,stype value))
+                                       ,@(and writer `((defmethod ,writer ((object ,type) ,stype)
+                                                         (#+sbcl declare #-sbcl declaim
+                                                          (type ,stype value))
                                                          (setf (gethash object ,stable) value))))
                                        ;; For Python compatibility
                                        (defmethod get-extension ((object ,type)
@@ -1357,7 +1358,8 @@ Arguments:
                        ,@(and reader `((defmethod ,reader ((object ,type))
                                          (gethash object ,stable ,default))))
                        ,@(and writer `((defmethod ,writer ((object ,type) value)
-                                         (declare (type ,stype value))
+                                         (#+sbcl declare #-sbcl declaim
+                                           (type ,stype value))
                                          (setf (gethash object ,stable) value))))
                        (defmethod get-extension ((object ,type) (slot (eql ',fname)))
                          (values (gethash object ,stable ,default)))

--- a/serialize.lisp
+++ b/serialize.lisp
@@ -385,7 +385,7 @@ Contains the INDEX of the field as according to protobuf, an internal
 OFFSET, the BOOL-NUMBER (for simple boolean fields), a flag ONEOF-P which indicates if the field
 is part of a oneof, the INITARG, the COMPLEX-FIELD datastructure.
 See field-descriptor for the distinction between index, offset, and bool-number."
-  index
+  (index -1 :type fixnum)
   offset
   bool-index
   oneof-p
@@ -427,6 +427,7 @@ See field-descriptor for the distinction between index, offset, and bool-number.
 ;; Given a field-number and a field-map, return the FIELD metadata or NIL.
 (declaim (inline find-in-field-map))
 (defun find-in-field-map (field-number field-map)
+  (declare (type fixnum field-number))
   (if (svref field-map 0)
       (unless (>= field-number (length field-map))
         (svref field-map field-number))

--- a/tests/custom-methods.lisp
+++ b/tests/custom-methods.lisp
@@ -80,6 +80,7 @@
   (unless (slot-boundp self '%fancything)
     (setf (slot-value self '%fancything) "-unset-")))
 
+(declaim (type fixnum *callcount-serialize*))
 (defvar *callcount-serialize* 0
   "The number of times we've called the customer serialize function.")
 

--- a/tests/wire-tests.lisp
+++ b/tests/wire-tests.lisp
@@ -116,7 +116,6 @@ Paramaters:
   PAIRS: Tuples of (encoded decoded) elements."
   (loop for (input assert-trueed) in pairs
         for assert-trueed-buf = (coerce assert-trueed '(vector (unsigned-byte 8)))
-        for filler = (random #xff)
         when encoder
           do (let* ((buf (make-octet-buffer 16))
                     (array (progn


### PR DESCRIPTION
There were many compilation warnings and notes for ccl and sbcl.
These were getting annoying.
Down to 4 on sbcl