### PR TITLE
Fix proto-equal being incorrect for repeated message fields

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -115,13 +115,15 @@ only if the same fields have been explicitly set."
           for slot-value-2
             = (when slot-value-1
                 (slot-value message-2 (proto-internal-field-name field)))
-
           when (and (not (eq lisp-type :bool))
                     (or (scalarp lisp-type) (find-enum lisp-type)))
             do (unless (scalar-field-equal slot-value-1 slot-value-2)
                  (return-from proto-equal nil))
           unless (and slot-value-1 slot-value-2)
             do (when (or slot-value-1 slot-value-2)
+                 (return-from proto-equal nil))
+          when (and slot-value-1 (eq (proto-label field) :repeated))
+            do (unless (= (length slot-value-1) (length slot-value-2))
                  (return-from proto-equal nil))
           when (and slot-value-1 (find-message lisp-type))
             do (loop for x in

--- a/tests/quick-tests.lisp
+++ b/tests/quick-tests.lisp
@@ -186,6 +186,15 @@
     (assert-true (proto-impl::proto-equal p q))
     (assert-false (proto-impl::proto-equal p q :exact t))
 
+    ;; Verify that proto-equal works for repeated message fields
+    (let* ((time1 (cl-protobufs.protobuf-unittest:make-time-protocol :debug-string (list "test1")))
+           (time2 (cl-protobufs.protobuf-unittest:make-time-protocol :debug-string (list "test2")))
+           (proto1 (cl-protobufs.protobuf-unittest:make-test-protocol :tp2 (list time1 time2)))
+           (proto2 (cl-protobufs.protobuf-unittest:make-test-protocol :tp2 (list time1))))
+      ;; proto-equal is asymmetric, so both sides must be checked.
+      (assert-false (proto-impl::proto-equal proto1 proto2))
+      (assert-false (proto-impl::proto-equal proto2 proto1)))
+
     ;; With a sub-object
     (let ((thirteen-1 (cl-protobufs.protobuf-unittest:make-thirteen))
           (thirteen-2 (cl-protobufs.protobuf-unittest:make-thirteen)))


### PR DESCRIPTION
Previously, this function would only verify that one list was a sublist
of the second list. Now, it properly checks for equality.