### PR TITLE
Save proto bytes that we can't deserialize for later

### DIFF
--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -1024,6 +1024,8 @@ Arguments:
 
          (export '(,public-constructor-name ,is-set-name))
          (defmethod clear ((,obj ,proto-type))
+           (setf (base-message-%%skipped-bytes ,obj)
+                 (make-byte-vector 0))
            ,@(mapcan (lambda (name)
                        (let ((clear-name (fintern "~A.CLEAR-~A" proto-type name)))
                          `((,clear-name ,obj))))

--- a/define-proto.lisp
+++ b/define-proto.lisp
@@ -1024,8 +1024,7 @@ Arguments:
 
          (export '(,public-constructor-name ,is-set-name))
          (defmethod clear ((,obj ,proto-type))
-           (setf (base-message-%%skipped-bytes ,obj)
-                 (make-byte-vector 0))
+           (setf (base-message-%%skipped-bytes ,obj) nil)
            ,@(mapcan (lambda (name)
                        (let ((clear-name (fintern "~A.CLEAR-~A" proto-type name)))
                          `((,clear-name ,obj))))

--- a/model-classes.lisp
+++ b/model-classes.lisp
@@ -22,7 +22,7 @@ Parameters:
 ;; Type for structure messages.
 (defstruct base-message
   "Base structure that all protobuf message structs inherit from."
-  (%%skipped-bytes (make-byte-vector 0 :adjustable t) :type byte-vector))
+  (%%skipped-bytes nil :type (or null byte-vector)))
 
 ;;; "Thread-local" variables
 

--- a/model-classes.lisp
+++ b/model-classes.lisp
@@ -21,7 +21,8 @@ Parameters:
 
 ;; Type for structure messages.
 (defstruct base-message
-  "Base structure that all protobuf message structs inherit from.")
+  "Base structure that all protobuf message structs inherit from."
+  (%%skipped-bytes (make-byte-vector 0 :adjustable t) :type byte-vector))
 
 ;;; "Thread-local" variables
 

--- a/serialize.lisp
+++ b/serialize.lisp
@@ -129,12 +129,13 @@
 (defun emit-skipped-bytes (object buffer)
   (declare (buffer buffer)
            (base-message object))
-  (let ((skipped-byte-length (length (base-message-%%skipped-bytes object))))
-    (if (zerop skipped-byte-length)
-        0
-        (progn
-          (buffer-ensure-space buffer skipped-byte-length)
-          (fast-octets-out buffer (base-message-%%skipped-bytes object))))))
+  (if (base-message-%%skipped-bytes object)
+      (progn
+        (buffer-ensure-space
+         buffer
+         (length (base-message-%%skipped-bytes object)))
+        (fast-octets-out buffer (base-message-%%skipped-bytes object)))
+      0))
 
 (defun emit-field (object field buffer)
   "Serialize a single field from an object to buffer


### PR DESCRIPTION
Suppose we have a proto message foo at version 1 and 2:
Version 1:
message foo {
  optional int one = 1;
}
Version 2:
message foo {
  optional int one = 1;
  optional int two = 2;
}

If we serialize a message at version 2, and deserialize the
message at version 1, we don't necessarily want to drop the bytes
If we serialize the the deserialized foo we should attach the 
skipped bytes to the new byte array so a future recipient can 
read them properly.