### PR TITLE
Add more general handling for 'null' fields.

### DIFF
--- a/tests/json-test.lisp
+++ b/tests/json-test.lisp
@@ -34,6 +34,15 @@
   \"one_level_nesting\": {
     \"int_field\": 2
   },
+  \"unknown_field_1\": [
+    {
+      \"sub_field_1\": 4,
+      \"sub_field_2\": 6
+    },
+    {
+      \"sub_field_3\": \"test\"
+    }
+  ],
   \"enum_vals\": [
     \"NONE\",
     \"TWENTY_ONE\"
@@ -50,7 +59,8 @@
   \"int64_field\": \"12\",
   \"sint64_field\": \"-1\",
   \"int_vals\": null,
-  \"oneof_int_field\": 5
+  \"oneof_int_field\": 5,
+  \"embedded_comment_a\": null
 }
 ")
 
@@ -74,6 +84,7 @@
     (assert-true (= -1 (sint64-field msg-parse)))
     (assert-true (eql 5 (oneof-int-field msg-parse)))
     (assert-false (int-vals msg-parse))
+    (assert-false (text-format-test.has-embedded-comment-a msg-parse))
     (assert-true (equalp (make-array 5 :element-type '(unsigned-byte 8)
                                        :initial-contents '(3 5 7 112 81))
                          (bytes-field msg-parse)))))


### PR DESCRIPTION
I missed one piece of syntax in the original PR. This PR fixes that. 

'null' can also appear as the value for a non-repeated field. This value
represents the default value of the type. Since JSON mappings are only
documented for proto3 semantics, this means that we should simply not
set the field to anything in this case. In proto2, this means that the
has-* function should return NIL if a field is parsed with a 'null'
value. This commit adds a test for this behavior.