### PR TITLE
Remove manual message definitions in test files

### DIFF
--- a/cl-protobufs.asd
+++ b/cl-protobufs.asd
@@ -209,7 +209,8 @@
    (:module "custom-methods-test"
     :serial t
     :pathname ""
-    :components ((:file "custom-methods")))
+    :components ((:protobuf-source-file "custom-proto")
+                 (:file "custom-methods")))
 
    (:module "deserialize-object-to-bytes-test"
     :serial t
@@ -290,7 +291,8 @@
    (:module "zigzag-test"
     :serial t
     :pathname ""
-    :components ((:file "zigzag-test")))
+    :components ((:protobuf-source-file "zigzag-proto")
+                 (:file "zigzag-test")))
 
    (:module "well-known-types-test"
     :serial t

--- a/tests/custom-methods.lisp
+++ b/tests/custom-methods.lisp
@@ -26,31 +26,8 @@
 (defpackage #:cl-protobufs.test.custom-proto
   (:use #:cl
         #:clunit
-        #:cl-protobufs)
-  ;; These are here because they are exported from the testschema
-  ;; schema below and not having them causes a build error.
-  (:export #:example-parent.clear-code
-           #:example-parent-%%is-set
-           #:example-parent.has-name
-           #:submessage.code
-           #:submessage.has-fancything
-           #:submessage.clear-fancything
-           #:make-example-parent
-           #:submessage.clear-code
-           #:submessage-%%is-set
-           #:example-parent.submessage
-           #:submessage.othercode
-           #:submessage.clear-othercode
-           #:submessage.fancything
-           #:example-parent.clear-submessage
-           #:example-parent.has-code
-           #:example-parent.has-submessage
-           #:example-parent.clear-name
-           #:submessage.has-code
-           #:make-submessage
-           #:example-parent.name
-           #:submessage.has-othercode
-           #:example-parent.code)
+        #:cl-protobufs
+        #:cl-protobufs.custom-proto)
   (:export :run))
 
 (in-package #:cl-protobufs.test.custom-proto)
@@ -61,24 +38,11 @@
   "Run all tests in the test suite."
   (cl-protobufs.test:run-suite 'custom-proto-suite))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (define-schema 'testschema
-    :syntax :proto2
-    :package 'cl-protobufs.test.custom-proto-test)
-  (define-message example-parent (:conc-name "")
-    (code :index 1 :type protobufs:int64 :label (:required) :json-name "code")
-    (name :index 3 :type string :label (:required) :json-name "name")
-    (submessage :index 4 :type (or null submessage) :label (:required) :json-name "submessage"))
-  (define-message submessage (:conc-name "")
-    (code :index 1 :type string :label (:required) :json-name "code")
-    (fancything :index 2 :type string :label (:required) :json-name "fancything")
-    (othercode :index 3 :type string :label (:required) :json-name "othercode")))
-
 ;; Helper to ensure the deserializer reconstructs this slot
 (defmethod initialize-instance :after ((self submessage) &rest initargs)
   (declare (ignore initargs))
-  (unless (slot-boundp self '%fancything)
-    (setf (slot-value self '%fancything) "-unset-")))
+  (unless (slot-boundp self 'cl-protobufs.custom-proto::%fancything)
+    (setf (slot-value self 'cl-protobufs.custom-proto::%fancything) "-unset-")))
 
 (declaim (type fixnum *callcount-serialize*))
 (defvar *callcount-serialize* 0
@@ -94,12 +58,12 @@
            (type fixnum size))
   ;; as a double-check that this was called.
   (incf *callcount-serialize*)
-  (let ((val (slot-value obj '%code)))
+  (let ((val (slot-value obj 'cl-protobufs.custom-proto::%code)))
     (when val
         (proto-impl::iincf
          size (proto-impl::serialize-scalar val :string 10 buf))))
   ;; skip the FANCYTHING slot
-  (let ((val (slot-value obj '%othercode)))
+  (let ((val (slot-value obj 'cl-protobufs.custom-proto::%othercode)))
     (when val
       (proto-impl::iincf
        size (proto-impl::serialize-scalar val :string 26 buf))))

--- a/tests/custom-proto.proto
+++ b/tests/custom-proto.proto
@@ -1,0 +1,21 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+syntax = "proto2";
+
+package custom_proto;
+
+message ExampleParent {
+  optional int32 code = 1;
+  optional string name = 3;
+  optional Submessage submessage = 4;
+}
+
+message Submessage {
+  optional string code = 1;
+  optional string fancything = 2;
+  optional string othercode = 3;
+}

--- a/tests/serialization-tests.lisp
+++ b/tests/serialization-tests.lisp
@@ -4,58 +4,11 @@
 ;;; license that can be found in the LICENSE file or at
 ;;; https://opensource.org/licenses/MIT.
 
-;; todo(jgodbout): Remove the remaining define-schema: automobile
-
 (defpackage #:cl-protobufs.test.serialization
   (:use #:cl
         #:clunit
         #:cl-protobufs
         #:cl-protobufs.serialization-test)
-  ;; These are here because they are exported from the automobile
-  ;; schema below and not having them causes a build error.
-  (:export #:+used+
-           #:+new+
-           #:+metallic+
-           #:+normal+
-           #:auto-color.has-b-value
-           #:buy-car-request.auto
-           #:make-automobile
-           #:make-buy-car-response
-           #:buy-car-response-%%is-set
-           #:automobile-%%is-set
-           #:auto-color.has-name
-           #:automobile.clear-model
-           #:buy-car-request.clear-auto
-           #:buy-car-response.clear-price
-           #:buy-car-response.price
-           #:buy-car-response.has-price
-           #:automobile.has-status
-           #:automobile.clear-status
-           #:automobile.color
-           #:buy-car-request.has-auto
-           #:automobile.status
-           #:auto-color.has-r-value
-           #:automobile.clear-color
-           #:automobile.has-color
-           #:auto-color.g-value
-           #:auto-color.clear-g-value
-           #:auto-color.b-value
-           #:auto-color.clear-b-value
-           #:automobile.has-model
-           #:buy-car-request-%%is-set
-           #:auto-color.clear-r-value
-           #:make-buy-car-request
-           #:auto-color.name
-           #:automobile.model
-           #:auto-color.clear-name
-           #:auto-color-%%is-set
-           #:auto-color.r-value
-           #:auto-color.has-g-value
-           #:make-auto-color
-           #:buy-car-request-%%bool-values
-           #:buy-car-response-%%bool-values
-           #:auto-color-%%bool-values
-           #:automobile-%%bool-values)
   (:export :run))
 
 (in-package #:cl-protobufs.test.serialization)
@@ -349,41 +302,10 @@
 ;; a method twice in one file using the *exact* *same* qualifiers and specializers.
 ;; The introspection-based (de)serialize functions don't have this issue
 ;; because nothing happens with regard to (de)serialization until just-in-time.
-;;
-(define-schema 'automobile
-  :package 'proto_test
-  ;; Does this really do anything?
-  :optimize :space)
-(define-enum auto-status ()
-  (new :index 1)
-  (used :index 2))
-(define-enum paint-type ()
-  (normal :index 1)
-  (metallic :index 2))
-(define-message auto-color
-    (:conc-name "")
-  (name    :index 1 :type string :label (:optional)      :json-name "name")
-  (r-value :index 2 :type proto:int32 :label (:required) :json-name "rValue")
-  (g-value :index 3 :type proto:int32 :label (:required) :json-name "gValue")
-  (b-value :index 4 :type proto:int32 :label (:required) :json-name "bValue")
-  (define-extension 1000 max))
-(define-extend auto-color
-    (:conc-name "")
-  (paint-type :index 1000 :type (or paint-type null) :label (:optional) :json-name "paintType"))
-(define-message automobile
-    (:conc-name "")
-  (model  :index 1 :type string :label (:required) :json-name "model")
-  (color  :index 2 :type (or null auto-color) :label (:required) :json-name "color")
-  (status :index 3 :type (or null auto-status) :label (:required) :default :new
-          :json-name "status"))
-(define-message buy-car-request ()
-  (auto :index 1 :type (or null automobile) :label (:required) :json-name "auto"))
-(define-message buy-car-response ()
-  (price :index 1 :type proto:uint32 :label (:optional) :json-name "price"))
-
 ;;; The define-service macro expands to code in a package named <current-package>-rpc.
 ;;; Normally the package would be created in the generated code but we do it manually
 ;;; here because we call define-service directly.
+
 (defpackage #:cl-protobufs.test.serialization-rpc (:use))
 
 (define-service buy-car ()

--- a/tests/serialization.proto
+++ b/tests/serialization.proto
@@ -191,3 +191,39 @@ message ProtoDifferentThanWire {
   optional string beginning = 1;
   optional string always = 2;
 }
+
+enum AutoStatus {
+  NEW = 1;
+  USED = 2;
+}
+
+enum PaintType {
+  NORMAL = 1;
+  METALLIC = 2;
+}
+
+message AutoColor {
+  optional string name = 1;
+  optional int32 r_value = 2;
+  optional int32 g_value = 3;
+  optional int32 b_value = 4;
+  extensions 1000 to 2000;
+}
+
+extend AutoColor {
+  optional PaintType paint_type = 1000;
+}
+
+message Automobile {
+  optional string model = 1;
+  optional AutoColor color = 2;
+  optional AutoStatus status = 3 [default = NEW];
+}
+
+message BuyCarRequest {
+  optional Automobile auto = 1;
+}
+
+message BuyCarResponse {
+  optional uint32 price = 1;
+}

--- a/tests/zigzag-proto.proto
+++ b/tests/zigzag-proto.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package zigzag_test;
+
+message Msg {
+  optional sint64 s = 1;
+  optional uint64 u = 2;
+  optional int64  i = 3;
+}

--- a/tests/zigzag-test.lisp
+++ b/tests/zigzag-test.lisp
@@ -8,29 +8,8 @@
   (:use #:cl
         #:clunit
         #:cl-protobufs
-        #:alexandria)
-  (:import-from #:proto-impl
-                #:proto-name
-                #:proto-fields
-                #:proto-services
-                #:proto-methods
-                #:proto-input-type
-                #:proto-output-type
-                #:proto-extended-fields
-                #:proto-class)
-  ;; These are here because they are exported from the zigzag
-  ;; schema below and not having them causes a build error.
-  (:export #:make-msg
-           #:msg-%%is-set
-           #:msg.clear-u
-           #:msg.clear-s
-           #:msg.has-u
-           #:msg.u
-           #:msg.has-i
-           #:msg.s
-           #:msg.clear-i
-           #:msg.has-s
-           #:msg.I)
+        #:alexandria
+        #:cl-protobufs.zigzag-test)
   (:export :run))
 
 (in-package #:cl-protobufs.test.zigzag)
@@ -44,22 +23,13 @@
 (defun expect-bytes (list array)
   (assert-true (equal (coerce list 'list) (coerce array 'list))))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (proto:define-schema 'zigzag-test
-    :syntax :proto2
-    :package 'proto-test)
-
-  (proto:define-message msg ()
-    (s :index 1 :type (or null proto:sint64) :label (:optional) :json-name "s")
-    (u :index 2 :type (or null proto:uint64) :label (:optional) :json-name "u")
-    (i :index 3 :type (or null proto:int64) :label (:optional) :json-name "i")))
-
 (defconstant +TAG-S+ (proto-impl::make-tag :int32 1))
 (defconstant +TAG-U+ (proto-impl::make-tag :int32 2))
 (defconstant +TAG-I+ (proto-impl::make-tag :int32 3))
 
-
-(define-constant +equal-loop-list+ '(%s %u %i)
+(define-constant +equal-loop-list+ '(cl-protobufs.zigzag-test::%s
+                                     cl-protobufs.zigzag-test::%u
+                                     cl-protobufs.zigzag-test::%i)
   :test #'equal
   :documentation "Fields to iterate over.")
 
@@ -88,10 +58,11 @@
     (unless (closer-mop:class-finalized-p class)
       (closer-mop:finalize-inheritance class))
     (let* ((slot
-             (find '%u (closer-mop:class-slots class) :key 'closer-mop:slot-definition-name))
+             (find 'cl-protobufs.zigzag-test::%u (closer-mop:class-slots class)
+                   :key 'closer-mop:slot-definition-name))
            (type (closer-mop:slot-definition-type slot)))
       #+sbcl ;; In non sbcl the int-name may differ
-      (assert-true (eq type '(or null uint64)))
+      (assert-true (eq type 'uint64))
       (assert-true (not (typep -10 type)))
       (assert-true (typep 10 type)))))
 


### PR DESCRIPTION
This makes development easier, since we don't need to go and update
these definitions whenever protoc changes.