### PR TITLE
Use `float-features` to handle infinite value

### DIFF
--- a/cl-protobufs.asd
+++ b/cl-protobufs.asd
@@ -266,6 +266,12 @@ and functionality for working with them."
     :depends-on ("lisp-alias")
     :components ((:file "lisp-alias-test")))
 
+   (:module "float-test"
+    :serial t
+    :pathname ""
+    :components ((:protobuf-source-file "float")
+                 (:file "float-test")))
+
    (:module "packed-test"
     :serial t
     :pathname ""

--- a/protoc/literals.cc
+++ b/protoc/literals.cc
@@ -16,11 +16,11 @@ namespace cl_protobufs {
 const std::string LispSimpleFtoa(float value) {
   std::string result = SimpleFtoa(value);
   if (result == "inf") {
-    GOOGLE_LOG(FATAL) << "single-float-positive-infinity";
+    return "float-features:single-float-positive-infinity";
   } else if (result == "-inf") {
-    GOOGLE_LOG(FATAL) <<  "single-float-negative-infinity";
+    return "float-features:single-float-negative-infinity";
   } else if (result == "nan") {
-    GOOGLE_LOG(FATAL) <<  "single-float-nan";
+    return "float-features:single-float-nan";
   }
 
   std::string::size_type pos = result.find('e', 0);
@@ -34,11 +34,11 @@ const std::string LispSimpleFtoa(float value) {
 const std::string LispSimpleDtoa(double value) {
   std::string result = SimpleDtoa(value);
   if (result == "inf") {
-    GOOGLE_LOG(FATAL) << "double-float-positive-infinity";
+    return "float-features:double-float-positive-infinity";
   } else if (result == "-inf") {
-    GOOGLE_LOG(FATAL) <<  "doubl-float-negative-infinity";
+    return "float-features:double-float-negative-infinity";
   } else if (result == "nan") {
-    GOOGLE_LOG(FATAL) <<  "double-float-nan";
+    return "float-features:double-float-nan";
   }
 
   std::string::size_type pos = result.find('e', 0);

--- a/tests/float-test.lisp
+++ b/tests/float-test.lisp
@@ -1,0 +1,49 @@
+;;; Copyright 2012-2020 Google LLC
+;;;
+;;; Use of this source code is governed by an MIT-style
+;;; license that can be found in the LICENSE file or at
+;;; https://opensource.org/licenses/MIT.
+
+(defpackage #:cl-protobufs.test.float
+  (:use #:cl #:clunit)
+  (:local-nicknames (#:pb #:cl-protobufs.float-test)
+                    (#:proto #:cl-protobufs))
+  (:export :run))
+
+(in-package #:cl-protobufs.test.float)
+
+(defsuite float-suite (cl-protobufs.test:root-suite))
+
+(defun run (&key use-debugger)
+  "Run all tests in the test suite.
+Parameters
+  USE-DEBUGGER: On assert failure bring up the debugger."
+  (clunit:run-suite 'float-suite :use-debugger use-debugger
+                                 :signal-condition-on-fail t))
+
+(deftest test-inf-nan (float-suite)
+  (flet ((test-pack (pack)
+           (assert-eql
+               (pb:float-pack.single-float-nan pack)
+               float-features:single-float-nan)
+           (assert-eql
+               (pb:float-pack.single-float-positive-infinity pack)
+               float-features:single-float-positive-infinity)
+           (assert-eql
+               (pb:float-pack.single-float-negative-infinity pack)
+               float-features:single-float-negative-infinity)
+           (assert-eql
+               (pb:float-pack.double-float-nan pack)
+               float-features:double-float-nan)
+           (assert-eql
+               (pb:float-pack.double-float-positive-infinity pack)
+               float-features:double-float-positive-infinity)
+           (assert-eql
+               (pb:float-pack.double-float-negative-infinity pack)
+               float-features:double-float-negative-infinity)))
+    (let ((pack (pb:make-float-pack)))
+      ;; test default values for `nan' and `inf'
+      (test-pack pack)
+      ;; test serialization and deserialization for `nan' and `inf'
+      (let ((pack (cl-protobufs:deserialize-from-bytes 'pb:float-pack (cl-protobufs:serialize-to-bytes pack))))
+        (test-pack pack)))))

--- a/tests/float.proto
+++ b/tests/float.proto
@@ -1,0 +1,18 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+syntax = "proto2";
+
+package float_test;
+
+message FloatPack {
+  optional float single_float_nan = 1 [default = nan];
+  optional float single_float_positive_infinity = 2 [default = inf];
+  optional float single_float_negative_infinity = 3 [default = -inf];
+  optional double double_float_nan = 4 [default = nan];
+  optional double double_float_positive_infinity = 5 [default = inf];
+  optional double double_float_negative_infinity = 6 [default = -inf];
+}


### PR DESCRIPTION
Hi! Noticing `float-features` was added as a dependency recently, I made it used for handling `inf` and `nan`, which are valid values in protobuf.