### PR TITLE
Support newer versions of protobuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 protoc/*.o
 protoc/*.cc
 protoc/*.h
-protoc/protoc-gen-lisp
+protoc/protoc-gen-cl-pb
 protoc/protoc_middleman

--- a/protoc/enum.cc
+++ b/protoc/enum.cc
@@ -6,7 +6,6 @@
 
 #include "enum.h"
 
-#include <google/protobuf/stubs/strutil.h>
 #include "proto2-descriptor-extensions.pb.h"
 #include "names.h"
 #include <google/protobuf/io/printer.h>
@@ -43,7 +42,7 @@ void EnumGenerator::Generate(io::Printer* printer) {
   for (int i = 0; i < descriptor_->value_count(); i++) {
     printer->Print("\n(:$name$ :index $number$)", "name",
                    ToLispEnumValue(descriptor_->value(i)->name()), "number",
-                   StrCat(descriptor_->value(i)->number()));
+                   absl::StrCat(descriptor_->value(i)->number()));
     printer->Annotate("name", descriptor_);
   }
   printer->Print(")");

--- a/protoc/field.cc
+++ b/protoc/field.cc
@@ -9,11 +9,9 @@
 #include <map>
 
 #include <cstdint>
-#include <google/protobuf/stubs/logging.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/extension_set.h>
-#include <google/protobuf/stubs/strutil.h>
 #include "proto2-descriptor-extensions.pb.h"
 #include "literals.h"
 #include "names.h"
@@ -82,7 +80,7 @@ const std::string FieldLispType(const FieldDescriptor* field) {
         type = "cl-protobufs:sint64";
         break;
       default:
-        GOOGLE_LOG(FATAL) << "Unsupported FileDescriptorType: "
+        ABSL_LOG(FATAL) << "Unsupported FileDescriptorType: "
                    << field->DebugString();
         break;
     }
@@ -149,7 +147,7 @@ const std::string FieldLispKind(const FieldDescriptor* field) {
       proto_kind = ":enum";
       break;
     default:
-      GOOGLE_LOG(FATAL) << "Unsupported FileDescriptorType: "
+      ABSL_LOG(FATAL) << "Unsupported FileDescriptorType: "
                  << field->DebugString();
       break;
   }
@@ -178,7 +176,7 @@ const std::string FieldLispLabel(const FieldDescriptor* field) {
       }
   }
 
-  GOOGLE_LOG(FATAL) << "Error determining field arity: " << field->DebugString();
+  ABSL_LOG(FATAL) << "Error determining field arity: " << field->DebugString();
   return "(:error)";
 }
 
@@ -192,20 +190,20 @@ const std::string FieldLispDefault(const FieldDescriptor* field) {
       return LispBool(field->default_value_bool());
     case FieldDescriptor::CPPTYPE_ENUM: {
       const EnumValueDescriptor* value = field->default_value_enum();
-      return StrCat(":", ToLispName(value->name()));
+      return absl::StrCat(":", ToLispName(value->name()));
     }
     case FieldDescriptor::CPPTYPE_INT32:
-      return StrCat(field->default_value_int32());
+      return absl::StrCat(field->default_value_int32());
     case FieldDescriptor::CPPTYPE_UINT32:
-      return StrCat(field->default_value_uint32());
+      return absl::StrCat(field->default_value_uint32());
     case FieldDescriptor::CPPTYPE_INT64:
-      return StrCat(field->default_value_int64());
+      return absl::StrCat(field->default_value_int64());
     case FieldDescriptor::CPPTYPE_UINT64:
-      return StrCat(field->default_value_uint64());
+      return absl::StrCat(field->default_value_uint64());
     case FieldDescriptor::CPPTYPE_STRING: {
       switch (field->type()) {
         case FieldDescriptor::TYPE_BYTES:
-          return StrCat(
+          return absl::StrCat(
               "(cl:make-array ", field->default_value_string().size(),
               " :element-type '(cl:unsigned-byte 8)", " :initial-contents '(",
               StringOctets(field->default_value_string()), "))");
@@ -220,7 +218,7 @@ const std::string FieldLispDefault(const FieldDescriptor* field) {
   // Unsupported by cl_protobufs.
   // case FieldDescriptor::CPPTYPE_MESSAGE:
   // Report errors as early as possible.
-  GOOGLE_LOG(FATAL) << "Unsupported FileDescriptorType: " << field->DebugString();
+  ABSL_LOG(FATAL) << "Unsupported FileDescriptorType: " << field->DebugString();
   return "";
 }
 }  // namespace
@@ -241,7 +239,7 @@ const std::string FieldLispName(const FieldDescriptor* field) {
 void GenerateField(io::Printer* printer, const FieldDescriptor* field) {
   std::map<std::string, std::string> vars;
   vars["name"] = FieldLispName(field);
-  vars["tag"] = StrCat(field->number());
+  vars["tag"] = absl::StrCat(field->number());
   vars["json-name"] = field->json_name();
   if (field->is_map()) {
     vars["key-type"] = FieldLispType(field->message_type()->field(0));
@@ -250,7 +248,7 @@ void GenerateField(io::Printer* printer, const FieldDescriptor* field) {
     vars["val-default"]
         = field->message_type()->field(1)->cpp_type()
         == FieldDescriptor::CPPTYPE_ENUM ?
-        StrCat("\n     :val-default ",
+        absl::StrCat("\n     :val-default ",
                      FieldLispDefault(field->message_type()->field(1))) : "";
     printer->Print(vars,
                    "\n(pi:define-map $name$\n"
@@ -268,7 +266,7 @@ void GenerateField(io::Printer* printer, const FieldDescriptor* field) {
     vars["default"] = field->has_default_value() ||
                       (field->cpp_type() == FieldDescriptor::CPPTYPE_ENUM &&
                        field->label() != FieldDescriptor::Label::LABEL_REPEATED)
-                      ? StrCat(" :default ", FieldLispDefault(field))
+                      ? absl::StrCat(" :default ", FieldLispDefault(field))
         : "";
     printer->Print(vars,
                    "\n($name$\n"

--- a/protoc/file.cc
+++ b/protoc/file.cc
@@ -11,7 +11,6 @@
 #include <memory>
 #include <set>
 
-#include <google/protobuf/stubs/strutil.h>
 #include "proto2-descriptor-extensions.pb.h"
 #include "enum.h"
 #include "field.h"

--- a/protoc/generator.cc
+++ b/protoc/generator.cc
@@ -59,7 +59,7 @@ bool LispGenerator::Generate(const FileDescriptor* file,
   if (annotate) {
     std::unique_ptr<io::ZeroCopyOutputStream> meta(
         output_directory->Open(file_name + ".meta"));
-    GOOGLE_CHECK(annotations.SerializeToZeroCopyStream(meta.get()));
+    ABSL_CHECK(annotations.SerializeToZeroCopyStream(meta.get()));
   }
 
   return true;
@@ -132,7 +132,7 @@ bool LispGenerator::GenerateAll(const std::vector<const FileDescriptor*>& files,
   if (annotate) {
     std::unique_ptr<io::ZeroCopyOutputStream> meta(
       context->Open(file_name + ".meta"));
-    GOOGLE_CHECK(annotations.SerializeToZeroCopyStream(meta.get()));
+    ABSL_CHECK(annotations.SerializeToZeroCopyStream(meta.get()));
   }
   return true;
 }

--- a/protoc/literals.cc
+++ b/protoc/literals.cc
@@ -5,16 +5,15 @@
 // https://opensource.org/licenses/MIT.
 
 #include "literals.h"
-
-#include <google/protobuf/stubs/logging.h>
-#include <google/protobuf/stubs/strutil.h>
+#include <google/protobuf/io/printer.h>
+#include <google/protobuf/io/strtod.h>
 
 namespace google {
 namespace protobuf {
 namespace cl_protobufs {
 
 const std::string LispSimpleFtoa(float value) {
-  std::string result = SimpleFtoa(value);
+  std::string result = io::SimpleFtoa(value);
   if (result == "inf") {
     return "float-features:single-float-positive-infinity";
   } else if (result == "-inf") {
@@ -32,7 +31,7 @@ const std::string LispSimpleFtoa(float value) {
 }
 
 const std::string LispSimpleDtoa(double value) {
-  std::string result = SimpleDtoa(value);
+  std::string result = io::SimpleDtoa(value);
   if (result == "inf") {
     return "float-features:double-float-positive-infinity";
   } else if (result == "-inf") {
@@ -65,7 +64,7 @@ const std::string StringOctets(const std::string& str) {
   std::string octets;
   for (char c : str) {
     if (!octets.empty()) octets += " ";
-    octets += StrCat(c & 0xff);
+    octets += absl::StrCat(c & 0xff);
   }
   return octets;
 }

--- a/protoc/message.cc
+++ b/protoc/message.cc
@@ -13,10 +13,9 @@
 #include <set>
 #include <unordered_set>
 
-#include <google/protobuf/stubs/logging.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/extension_set.h>
-#include <google/protobuf/stubs/strutil.h>
+#include <google/protobuf/io/strtod.h>
 #include "proto2-descriptor-extensions.pb.h"
 #include "enum.h"
 #include "field.h"
@@ -158,15 +157,15 @@ void MessageGenerator::GenerateSource(io::Printer* printer,
     printer->Print("\n;; Extension ranges");
     for (int i = 0; i < descriptor_->extension_range_count(); ++i) {
       const Descriptor::ExtensionRange* range = descriptor_->extension_range(i);
-      int start = range->start;
-      int end = range->end;
+      int start = range->start_;
+      int end = range->end_;
       printer->Print(
-          "\n(pi:define-extension $start$ $end$)", "start", StrCat(start),
+          "\n(pi:define-extension $start$ $end$)", "start", absl::StrCat(start),
           // The end is inclusive in cl_protobufs.
           // For some reason, the extension number is generated as
           // 0x7ffffffe when specified as 'max', but the max must be
           // (2^29 - 1).
-          "end", StrCat(std::min(kMaxExtensionNumber, end - 1)));
+          "end", absl::StrCat(std::min(kMaxExtensionNumber, end - 1)));
     }
   }
 

--- a/protoc/names.cc
+++ b/protoc/names.cc
@@ -10,10 +10,12 @@
 
 #include <ctype.h>
 
-#include <google/protobuf/stubs/macros.h>
+#include <absl/strings/ascii.h>
+#include <absl/strings/str_join.h>
+#include <absl/strings/str_replace.h>
+#include <absl/strings/str_split.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/extension_set.h>
-#include <google/protobuf/stubs/strutil.h>
 // #include <google/protobuf/stubs/str_join.h>
 // #include <google/protobuf/stubs/str_replace.h>
 #include "proto2-descriptor-extensions.pb.h"
@@ -47,6 +49,11 @@ CharType CharacterType(const char c) {
   } else {
     return unknown;
   }
+}
+
+const std::string ToUpper(std::string s) {
+  absl::AsciiStrToUpper(&s);
+  return s;
 }
 
 const std::string NonDestructiveStrToLower(std::string s) {
@@ -145,8 +152,8 @@ const std::string EnumLispName(const EnumDescriptor* descriptor) {
 
 const std::string ToLispEnumValue(const std::string& name) {
   // Enum values are usually uppercase separated by underscore.
-  std::string v = StringReplace(name, "_", "-", true);
-  LowerString(&v);
+  std::string v = absl::StrReplaceAll(name, {{"_", "-"}});
+  StrToLower(&v);
   return v;
 }
 
@@ -222,8 +229,8 @@ bool CamelIsSpitting(const std::string& name) {
 }
 
 const std::string ToLispAliasSymbolName(const std::string& symbol_name) {
-  auto splitter = Split(symbol_name, ":", true);
-  return NonDestructiveStrToLower(Join(splitter, "::"));
+  auto splitter = absl::StrSplit(symbol_name, ":");
+  return NonDestructiveStrToLower(absl::StrJoin(splitter, "::"));
 }
 
 }  // namespace cl_protobufs

--- a/protoc/names.h
+++ b/protoc/names.h
@@ -18,6 +18,7 @@ namespace google {
 namespace protobuf {
 namespace cl_protobufs {
 
+const std::string ToUpper(std::string s);
 const std::string NonDestructiveStrToLower(std::string s);
 
 const void StrToLower(std::string* s);

--- a/protoc/service.cc
+++ b/protoc/service.cc
@@ -7,10 +7,8 @@
 #include "service.h"
 
 #include <cstdint>
-#include <google/protobuf/stubs/logging.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/message.h>
-#include <google/protobuf/stubs/strutil.h>
 #include "literals.h"
 #include "names.h"
 #include <google/protobuf/io/printer.h>
@@ -56,13 +54,13 @@ std::string MethodOptionValue(const MethodOptions& method_options,
   const Reflection* reflection = method_options.GetReflection();
   switch (field->cpp_type()) {
     case FieldDescriptor::CPPTYPE_INT32:
-      return StrCat(reflection->GetInt32(method_options, field));
+      return absl::StrCat(reflection->GetInt32(method_options, field));
     case FieldDescriptor::CPPTYPE_INT64:
-      return StrCat(reflection->GetInt64(method_options, field));
+      return absl::StrCat(reflection->GetInt64(method_options, field));
     case FieldDescriptor::CPPTYPE_UINT32:
-      return StrCat(reflection->GetUInt32(method_options, field));
+      return absl::StrCat(reflection->GetUInt32(method_options, field));
     case FieldDescriptor::CPPTYPE_UINT64:
-      return StrCat(reflection->GetUInt64(method_options, field));
+      return absl::StrCat(reflection->GetUInt64(method_options, field));
     case FieldDescriptor::CPPTYPE_DOUBLE:
       return LispSimpleDtoa(reflection->GetDouble(method_options, field));
     case FieldDescriptor::CPPTYPE_FLOAT:
@@ -72,12 +70,12 @@ std::string MethodOptionValue(const MethodOptions& method_options,
     case FieldDescriptor::CPPTYPE_ENUM: {
       const EnumValueDescriptor* value =
           reflection->GetEnum(method_options, field);
-      return StrCat(":", ToLispName(value->name()));
+      return absl::StrCat(":", ToLispName(value->name()));
     }
     case FieldDescriptor::CPPTYPE_STRING:
       return LispEscapeString(reflection->GetString(method_options, field));
     case FieldDescriptor::CPPTYPE_MESSAGE:
-      GOOGLE_LOG(FATAL) << "Unsupported method option: " << field->name();
+      ABSL_LOG(FATAL) << "Unsupported method option: " << field->name();
   }
   return "";
 }
@@ -93,7 +91,7 @@ void GenerateMethodOptions(io::Printer* printer,
       continue;
     }
     // Currently every non-custom method option is non-repeated.
-    GOOGLE_CHECK(!field->is_repeated());
+    ABSL_CHECK(!field->is_repeated());
     if (method_options.GetReflection()->HasField(method_options, field)) {
       options.emplace_back(LispEscapeString(field->name()));
       options.emplace_back(MethodOptionValue(method_options, field));


### PR DESCRIPTION
This library doesn't compile with newer versions of protobuf (see https://github.com/qitab/cl-protobufs/issues/402), because some functions have been moved/renamed.

After I completed this patch, I realized that this duplicates efforts that already exist:
- https://github.com/qitab/cl-protobufs/pull/426
- https://github.com/qitab/cl-protobufs/pull/420
- https://github.com/qitab/cl-protobufs/pull/401
- https://github.com/qitab/cl-protobufs/pull/397

But this is all tidy and in a smaller and more manageable diff. Ultimately because this is a Google library you might opt to close this PR and merge those others instead :)

fixes #402 